### PR TITLE
fixed create/delete XMLs for multiple values

### DIFF
--- a/lib/Net/Amazon/Route53/ResourceRecordSet.pm
+++ b/lib/Net/Amazon/Route53/ResourceRecordSet.pm
@@ -92,9 +92,7 @@ sub create
                <Type>%s</Type>
                <TTL>%s</TTL>
                <ResourceRecords>
-                  <ResourceRecord>
-                    %s
-                  </ResourceRecord>
+                  %s
                </ResourceRecords>
             </ResourceRecordSet>
          </Change>
@@ -105,7 +103,7 @@ ENDXML
     my $request_xml = sprintf( $request_xml_str,
         map { $_ }
         $self->type, $self->name, $self->name, $self->type, $self->ttl,
-        join( "\n", map { "<Value>$_</Value>" } @{ $self->values } ) );
+        join( "\n", map { "<ResourceRecord><Value>$_</Value></ResourceRecord>" } @{ $self->values } ) );
     my $resp = $self->route53->request(
         'post',
         'https://route53.amazonaws.com/2010-10-01/' . $self->hostedzone->id . '/rrset',
@@ -161,9 +159,7 @@ sub delete
                <Type>%s</Type>
                <TTL>%s</TTL>
                <ResourceRecords>
-                  <ResourceRecord>
-                    %s
-                  </ResourceRecord>
+                  %s
                </ResourceRecords>
             </ResourceRecordSet>
          </Change>
@@ -173,7 +169,7 @@ sub delete
 ENDXML
     my $request_xml = sprintf( $request_xml_str,
         (map { $_ } ( $self->type, $self->name, $self->name, $self->type, $self->ttl )),
-        join( "\n", map { "<Value>" . $_ . "</Value>" } @{ $self->values } ) );
+        join( "\n", map { "<ResourceRecord><Value>" . $_ . "</Value></ResourceRecord>" } @{ $self->values } ) );
     my $resp = $self->route53->request(
         'post',
         'https://route53.amazonaws.com/2010-10-01/' . $self->hostedzone->id . '/rrset',


### PR DESCRIPTION
Hi, 

I've found an issue to set multiple values for a record like MX:
```route53 -keyname abcde record create example.com. --name example.com --type MX --ttl 86400 --value "1 a.mx.example.com: --value "2 b.mx.example.com"

```

Please review the code.  

Thanks,

```
