### PR TITLE
Hello!

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+
+    - Changes by contributors:
+      - Retrieve more than 100 resource record sets at once
+      - Test the retrieval of more than 100 resource record sets at once.
+      - Return NOOP status from atomic_update if the changeset is empty
+
 v0.113630 - 2011-12-29
     - Changes by contributors:
       - Fix templating error in Net::Amazon::Route53::_get_change_xml

--- a/README.mkd
+++ b/README.mkd
@@ -26,11 +26,15 @@ Implemented
 - List records matching a name, type, ttl or values for a hosted zone
 - Delete a record matching a name, type, ttl or value for a hosted zone
 - Create a new record of given name, type, ttl and value(s) for a hosted zone
+- Create a "change record" option, which does a "delete" and a "create" action in one request: See Net::Amazon::Route53::ResourceRecordSet::Change.
+- Support retrieving more than 100 records at once in Net::Amazon::Route53::HostedZone::resource_record_sets
 
 To do
 -----
 
-- Create a "change record" option, which does a "delete" and a "create" action in one request.
+- Support changing more than 100 records at once
+- Support deleting more than 100 records at once
+
 
 This software is copyright (c) 2011 by Marco Fontani.
 

--- a/lib/Net/Amazon/Route53.pm
+++ b/lib/Net/Amazon/Route53.pm
@@ -318,6 +318,9 @@ sub atomic_update {
 
     my $batch_xml = $self->_batch_request_header;
 
+    # Do not attempt to push an empty changeset
+    return Net::Amazon::Route53::Change->new(route53 => $self, status => 'NOOP') if @change_objects+@deletions+@creates < 1;
+
     for my $rr (@change_objects) {
         $rr->name =~ /\.$/ or die "Zone name needs to end in a dot, to be changed\n";
         my $change_xml = $self->_get_change_xml($rr);

--- a/lib/Net/Amazon/Route53/HostedZone.pm
+++ b/lib/Net/Amazon/Route53/HostedZone.pm
@@ -84,25 +84,31 @@ has 'resource_record_sets' => (
     lazy    => 1,
     default => sub {
         my $self = shift;
-        my $resp =
-          $self->route53->request( 'get', 'https://route53.amazonaws.com/2010-10-01/' . $self->id . '/rrset' );
         my @resource_record_sets;
-        for my $res ( @{ $resp->{ResourceRecordSets}{ResourceRecordSet} } ) {
-            push @resource_record_sets,
-              Net::Amazon::Route53::ResourceRecordSet->new(
-                route53    => $self->route53,
-                hostedzone => $self,
-                name       => decode_entities($res->{Name}),
-                ttl        => $res->{TTL},
-                type       => decode_entities($res->{Type}),
-                values     => [
-                    map { decode_entities($_->{Value}) } @{
-                        ref $res->{ResourceRecords}{ResourceRecord} eq 'ARRAY'
-                        ? $res->{ResourceRecords}{ResourceRecord}
-                        : [ $res->{ResourceRecords}{ResourceRecord} ]
-                      }
-                ],
-              );
+        my $next_record_name = '';
+        while (1) {
+            my $resp = $self->route53->request( 'get', 'https://route53.amazonaws.com/2010-10-01/' . $self->id . '/rrset?maxitems=100'.$next_record_name );
+            my $set = $resp->{ResourceRecordSets}{ResourceRecordSet};
+            my @results = ref($set) eq 'ARRAY' ? @$set : ($set);
+            for my $res ( @results ) {
+                push @resource_record_sets,
+                  Net::Amazon::Route53::ResourceRecordSet->new(
+                    route53    => $self->route53,
+                    hostedzone => $self,
+                    name       => decode_entities($res->{Name}),
+                    ttl        => $res->{TTL},
+                    type       => decode_entities($res->{Type}),
+                    values     => [
+                        map { decode_entities($_->{Value}) } @{
+                            ref $res->{ResourceRecords}{ResourceRecord} eq 'ARRAY'
+                            ? $res->{ResourceRecords}{ResourceRecord}
+                            : [ $res->{ResourceRecords}{ResourceRecord} ]
+                          }
+                    ],
+                  );
+            }
+            last unless $resp->{NextRecordName};
+            $next_record_name = '&name='.$resp->{NextRecordName};
         }
         \@resource_record_sets;
     }

--- a/t/01-retrieve-more-than-100-rrsets.t
+++ b/t/01-retrieve-more-than-100-rrsets.t
@@ -1,0 +1,156 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Net::Amazon::Route53;
+use Test::More;
+use Test::Exception;
+
+my $access_key_id     = $ENV{AWS_ACCESS_KEY_ID};
+my $secret_access_key = $ENV{AWS_SECRET_ACCESS_KEY};
+my $test_domain       = $ENV{AWS_TEST_DOMAIN};
+
+plan skip_all => '
+#################################################################
+#                                                               #
+#  You MUST set $ENV{AWS_ACCESS_KEY_ID}, $ENV{AWS_TEST_DOMAIN}, #
+#  and $ENV{AWS_SECRET_ACCESS_KEY} to test this!                #
+#                                                               #
+#################################################################'
+    unless ( $access_key_id && $secret_access_key && $test_domain );
+plan tests => 15;
+
+$test_domain =~ s/\..+?$//g;
+my $fq_test_domain = $test_domain . ".test.";
+diag "
+##############################################################
+                                                               
+  This test will create a hosted zone for $fq_test_domain 
+  and will create and delete records in it, and delete the     
+  hosted zone at the end.                                      
+                                                               
+###############################################################";
+
+my $route53;
+my $hosted_zone;
+lives_ok {
+    $route53 = Net::Amazon::Route53->new(
+        id  => $access_key_id,
+        key => $secret_access_key
+    );
+}
+"I can make a new Net::Amazon::Route53 object";
+ok( defined($route53), "That object is defined" );
+
+($hosted_zone) = $route53->get_hosted_zones($fq_test_domain);
+
+if ( !$hosted_zone ) {
+    $hosted_zone = Net::Amazon::Route53::HostedZone->new(
+        route53         => $route53,
+        name            => $fq_test_domain,
+        callerreference => 'Route53TestDomain-'
+            . int( rand(1_000_000_000_000_000) ),
+        comment => 'Installing the perl module Net::Amazon::Route53'
+    );
+    my $change = $hosted_zone->create(1);
+    if ( $change->status eq 'INSYNC' ) {
+        is( $change->status, 'INSYNC', "I created a new hosted zone ".$hosted_zone->name );
+        lives_ok {
+            ($hosted_zone) = $route53->get_hosted_zones($fq_test_domain);
+        }
+        "I can get my newly created zone from the Route53 object";
+    }
+} else {
+    my $current_records = $hosted_zone->resource_record_sets;
+    if ( scalar(@$current_records) ) {
+        my ($ns_record)  = grep { $_->type eq 'NS' } @$current_records;
+        my ($soa_record) = grep { $_->type eq 'SOA' } @$current_records;
+        my $first_delete_amount
+            = @$current_records > 98 ? 98 : $#{$current_records};
+        my @first_deletes  = @{$current_records}[ 0 .. $first_delete_amount ];
+        my $first_deletion = $route53->atomic_update( \@first_deletes,
+            [ $ns_record, $soa_record ], 1 );
+        ok( $first_deletion->status =~ /INSYNC|NOOP/,
+            "My first delete for cleanup of the zone was successful" );
+        my $leftover_records = $hosted_zone->resource_record_sets;
+
+        if ( @$leftover_records > 2 ) {
+            my ($ns_record)  = grep { $_->type eq 'NS' } @$current_records;
+            my ($soa_record) = grep { $_->type eq 'SOA' } @$current_records;
+            my $second_deletion = $route53->atomic_update( $leftover_records,
+                [ $ns_record, $soa_record ], 1 );
+            ok( $second_deletion->status =~ /INSYNC|NOOP/,
+                "My second delete for cleanup of the zone was successful" );
+        }
+    }
+}
+
+ok( defined($hosted_zone),
+    "My hosted zone " . $hosted_zone->name . " is defined" );
+
+my @records = map {
+    my $number = sprintf( "%03d", $_ + 1 );
+    Net::Amazon::Route53::ResourceRecordSet->new(
+        route53    => $route53,
+        hostedzone => $hosted_zone,
+        name       => 'host-' . $number . '.' . $fq_test_domain,
+        ttl        => 600,
+        type       => 'CNAME',
+        values => [ 'ec2-50-17-121-' . $number . '.compute-1.amazonaws.com' ],
+        )
+} ( 0 .. 100 );
+
+is( scalar(@records), 101,
+    "I have made 101 new Net::Amazon::Route53::ResourceRecordSet objects" );
+
+my @first_100 = @records[ 0 .. 99 ];
+my @last_one  = ( $records[100] );
+
+my $first_creation = $route53->batch_create( \@first_100, 1 );
+is( $first_creation->status, 'INSYNC',
+    "I saved my first 100 records to Route53" );
+
+my $second_creation = $route53->batch_create( \@last_one, 1 );
+is( $second_creation->status, 'INSYNC',
+    "I saved my last 1 record to Route53" );
+
+my $new_route53;
+lives_ok {
+    $new_route53 = Net::Amazon::Route53->new(
+        id  => $access_key_id,
+        key => $secret_access_key
+    );
+}
+"I can make a second Route53 object";
+
+($hosted_zone) = $new_route53->get_hosted_zones($fq_test_domain);
+
+ok( defined($hosted_zone),
+    "And I can get my hosted zone " . $hosted_zone->name );
+my $rrsets;
+lives_ok { $rrsets = $hosted_zone->resource_record_sets }
+"I can call the resource_record_sets method on my hosted zone";
+
+is( scalar(@$rrsets), 103, "And I have 103 records in that set" );
+
+($hosted_zone) = $new_route53->get_hosted_zones($fq_test_domain);
+my ($ns_record)  = grep { $_->type eq 'NS' } @$rrsets;
+my ($soa_record) = grep { $_->type eq 'SOA' } @$rrsets;
+my $first_delete_amount = @$rrsets > 98 ? 98 : $#{$rrsets};
+my @first_deletes = @{$rrsets}[ 0 .. $first_delete_amount ];
+my $first_deletion
+    = $route53->atomic_update( \@first_deletes, [ $ns_record, $soa_record ],
+    1 );
+ok( $first_deletion->status =~ /INSYNC|NOOP/,
+    "My first delete for final cleanup of the zone was successful" );
+my $leftover_records = $hosted_zone->resource_record_sets;
+
+if ( @$leftover_records > 2 ) {
+    my ($ns_record)  = grep { $_->type eq 'NS' } @$rrsets;
+    my ($soa_record) = grep { $_->type eq 'SOA' } @$rrsets;
+    my $second_deletion = $route53->atomic_update( $leftover_records,
+        [ $ns_record, $soa_record ], 1 );
+    ok( $second_deletion->status =~ /INSYNC|NOOP/,
+        "My second delete for final cleanup of the zone was successful" );
+}
+my $zone_deletion = $hosted_zone->delete(1);
+is( $zone_deletion->status, 'INSYNC', "I can delete my zone finally" );


### PR DESCRIPTION
I have another change to support returning more than 100 resource record sets from the hosted zone. My ambition was to support more-than-100 throughout the code, but time got the better of me. There's a test for this new functionality also. And I also return from atomic_update early if there are no changes to send. Amazon throws an error if you send an empty changeset.
