### PR TITLE
Croak on 'ALIAS' records

### DIFF
--- a/lib/Net/Amazon/Route53/HostedZone.pm
+++ b/lib/Net/Amazon/Route53/HostedZone.pm
@@ -93,7 +93,7 @@ has 'resource_record_sets' => (
                 route53    => $self->route53,
                 hostedzone => $self,
                 name       => decode_entities($res->{Name}),
-                ttl        => $res->{TTL},
+                ttl        => $res->{TTL} || 0,
                 type       => decode_entities($res->{Type}),
                 values     => [
                     map { decode_entities($_->{Value}) } @{


### PR DESCRIPTION
Calling $zone->resource_record_sets() on a zone with 'ALIAS' records causes Net::Amazon::Route53::HostedZone to croak. The ALIAS record does not have a TTL defined (when looking at the AWS console) and therefore fails attribute validation:

Attribute (ttl) does not pass the type constraint because: Validation failed for 'Int' with value undef at /usr/lib/perl5/Mouse/Util.pm line 361
    Mouse::Util::throw_error('Mouse::Meta::Attribute=HASH(0x321c4f8)', 'Attribute (ttl) does not pass the type constraint because: Va...', 'data', undef, 'depth', -1) called at /usr/share/perl5/Net/Amazon/Route53/HostedZone.pm line 101
    Net::Amazon::Route53::HostedZone::**ANON**('Net::Amazon::Route53::HostedZone=HASH(0x402cf70)') called at 
