### PR TITLE
Change from straight-up Mouse to Any::Moose

### DIFF
--- a/lib/Net/Amazon/Route53.pm
+++ b/lib/Net/Amazon/Route53.pm
@@ -8,7 +8,7 @@ use Digest::HMAC_SHA1;
 use MIME::Base64;
 use XML::Bare;
 use HTML::Entities;
-use Mouse;
+use Any::Moose;
 
 use Net::Amazon::Route53::HostedZone;
 use Net::Amazon::Route53::ResourceRecordSet::Change;

--- a/lib/Net/Amazon/Route53/Change.pm
+++ b/lib/Net/Amazon/Route53/Change.pm
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 package Net::Amazon::Route53::Change;
-use Mouse;
+use Any::Moose;
 use HTML::Entities;
 
 =head2 SYNOPSIS
@@ -69,7 +69,7 @@ sub refresh
     }
 }
 
-no Mouse;
+no Any::Moose;
 
 =head1 AUTHOR
 

--- a/lib/Net/Amazon/Route53/HostedZone.pm
+++ b/lib/Net/Amazon/Route53/HostedZone.pm
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 package Net::Amazon::Route53::HostedZone;
-use Mouse;
+use Any::Moose;
 use HTML::Entities;
 
 use Net::Amazon::Route53::Change;
@@ -204,7 +204,7 @@ sub delete
     return $change;
 }
 
-no Mouse;
+no Any::Moose;
 
 =head1 AUTHOR
 

--- a/lib/Net/Amazon/Route53/ResourceRecordSet.pm
+++ b/lib/Net/Amazon/Route53/ResourceRecordSet.pm
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 package Net::Amazon::Route53::ResourceRecordSet;
-use Mouse;
+use Any::Moose;
 use XML::Bare;
 use HTML::Entities;
 
@@ -188,7 +188,7 @@ ENDXML
     return $change;
 }
 
-no Mouse;
+no Any::Moose;
 
 =head1 AUTHOR
 

--- a/lib/Net/Amazon/Route53/ResourceRecordSet/Change.pm
+++ b/lib/Net/Amazon/Route53/ResourceRecordSet/Change.pm
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 package Net::Amazon::Route53::ResourceRecordSet::Change;
-use Mouse;
+use Any::Moose;
 extends "Net::Amazon::Route53::ResourceRecordSet";
 
 =head2 SYNOPSIS
@@ -109,7 +109,7 @@ ENDXML
     return $change;
 }
 
-no Mouse;
+no Any::Moose;
 
 =head1 AUTHOR
 


### PR DESCRIPTION
This will allow the original design of using Mouse to prevail, unless Moose is
either already loaded or specifically asked for (as some may do).