### PR TITLE
Fixed memory leak

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+v0.123251 - 2013-01-19
+    - Fixed memory leak by adding "weak_ref => 1" for attributes of type
+      Net::Amazon::Route53 and  Net::Amazon::Route53::HostedZone
+
 v0.123250 - 2012-11-20
     - #7: fix undefined decode_entities in ::ResourceRecordSet::Change
 

--- a/lib/Net/Amazon/Route53/Change.pm
+++ b/lib/Net/Amazon/Route53/Change.pm
@@ -23,7 +23,7 @@ to Amazon's Route 53 service
 
 =cut
 
-has 'route53' => ( is => 'rw', isa => 'Net::Amazon::Route53', required => 1, );
+has 'route53' => ( is => 'rw', isa => 'Net::Amazon::Route53', required => 1, weak_ref => 1 );
 
 =head3 id
 

--- a/lib/Net/Amazon/Route53/HostedZone.pm
+++ b/lib/Net/Amazon/Route53/HostedZone.pm
@@ -26,7 +26,7 @@ to Amazon's Route 53 service
 
 =cut
 
-has 'route53' => ( is => 'rw', isa => 'Net::Amazon::Route53', required => 1, );
+has 'route53' => ( is => 'rw', isa => 'Net::Amazon::Route53', required => 1, weak_ref => 1 );
 
 =head3 id
 

--- a/lib/Net/Amazon/Route53/ResourceRecordSet.pm
+++ b/lib/Net/Amazon/Route53/ResourceRecordSet.pm
@@ -28,8 +28,8 @@ The L<Net::Amazon::Route53::HostedZone> object this hosted zone refers to
 
 =cut
 
-has 'route53'    => ( is => 'rw', isa => 'Net::Amazon::Route53',             required => 1, );
-has 'hostedzone' => ( is => 'rw', isa => 'Net::Amazon::Route53::HostedZone', required => 1 );
+has 'route53'    => ( is => 'rw', isa => 'Net::Amazon::Route53',             required => 1, weak_ref => 1 );
+has 'hostedzone' => ( is => 'rw', isa => 'Net::Amazon::Route53::HostedZone', required => 1, weak_ref => 1 );
 
 =head3 name
 


### PR DESCRIPTION
Hey Marco

Thanks for this great module!

I've found a memory leak which occures due to attributes of type Net::Amazon::Route53 and Net::Amazon::Route53::HostedZone which haven't the weak_ref parameter. Adding weak_ref removes this leak.

Best
Ulrich