### PR TITLE
Don't die when no zones setup @ aws

### DIFF
--- a/lib/Net/Amazon/Route53.pm
+++ b/lib/Net/Amazon/Route53.pm
@@ -148,7 +148,9 @@ sub get_hosted_zones
     while (1) {
         my $resp =
           $self->request( 'get', 'https://route53.amazonaws.com/2010-10-01/hostedzone?maxitems=100' . $start_marker );
-        push @zones, ( ref $resp->{HostedZones}{HostedZone} eq 'ARRAY' ? @{ $resp->{HostedZones}{HostedZone} } : $resp->{HostedZones}{HostedZone} );
+        if($resp->{HostedZones}) { 
+            push @zones, ( ref $resp->{HostedZones}{HostedZone} eq 'ARRAY' ? @{ $resp->{HostedZones}{HostedZone} } : $resp->{HostedZones}{HostedZone} );
+        }
         last if $resp->{IsTruncated} eq 'false';
         $start_marker = '?marker=' . $resp->{NextMarker};
     }


### PR DESCRIPTION
If you call get_hosted_zones() on an aws account with no zones setup yet, this function dies since {HostedZones} ends up as an empty string.

I tried to use this library on a project to sync my tinydns hosted zone up to amazon, and got an error right away :(

This is just a simple patch to not die out the gate if nothing's setup @ aws.