### PR TITLE
dist.ini kwalitee amendments

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,12 @@ copyright_holder = Marco Fontani
 [GatherDir]
 [PruneCruft]
 [AutoPrereqs]
+[Prereqs]
+perl = 5.006
+[Prereqs / TestRequires]
+Pod::Coverage::TrustPod = 0
+Test::Pod               = 1.41
+Test::Pod::Coverage     = 1.08
 [PerlTidy]
 [AutoVersion]
 major = 0
@@ -15,6 +21,7 @@ bugtracker.web = https://github.com/mfontani/Net-Amazon-Route53/issues
 repository.url = git://github.com/mfontani/Net-Amazon-Route53.git
 repository.web = https://github.com/mfontani/Net-Amazon-Route53
 repository.type = git
+[MetaProvides::Package]
 [PkgVersion]
 [ManifestSkip]
 [MetaYAML]


### PR DESCRIPTION
I've been assigned this dist for November as part of the [CPAN Pull Request Challenge](http://cpan-prc.org) - thanks for participating. There were [some items on CPANTS](https://cpants.cpanauthors.org/dist/Net-Amazon-Route53) which this PR addresses, namely:

- Minimum version of perl specified
- Author test deps added
- Provides added

Note that the author test deps obviously add to the total deps even though the average user will never need them. I can't immediately see a way around this in Dist::Zilla but it's not my usual deployment tool so perhaps I've missed something. Please get back to me if you need this tweaked before merging.